### PR TITLE
Fixed quote enclosed TXT records that contained semicolons.

### DIFF
--- a/lib/dns/zone/rr.rb
+++ b/lib/dns/zone/rr.rb
@@ -20,7 +20,8 @@ module DNS
       # @return [Object]
       def self.load(string, options = {})
         # strip comments, unless its escaped.
-        string.gsub!(/(?<!\\);.*/o, "");
+        # skip semicolons within "quote segments" (TXT records)
+        string.gsub!(/((?<!\\);)(?=(?:[^"]|"[^"]*")*$).*/o, "")
 
         captures = string.match(REGEX_RR)
         return nil unless captures

--- a/lib/dns/zone/rr/record.rb
+++ b/lib/dns/zone/rr/record.rb
@@ -63,7 +63,8 @@ class DNS::Zone::RR::Record
   # @return [String] remaining RDATA
   def load_general_and_get_rdata(string, options = {})
     # strip comments, unless its escaped.
-    string.gsub!(/(?<!\\);.*/o, "");
+    # skip semicolons within "quote segments" (TXT records)
+    string.gsub!(/((?<!\\);)(?=(?:[^"]|"[^"]*")*$).*/o, "")
 
     captures = string.match(DNS::Zone::RR::REGEX_RR)
     return nil unless captures

--- a/test/rr_test.rb
+++ b/test/rr_test.rb
@@ -27,6 +27,14 @@ class RRTest < DNS::Zone::TestCase
     assert_equal 'TXT', rr.type
     assert_equal 'test text', rr.text
   end
+  
+  def test_load_txt_semicolon_rr
+    rr = DNS::Zone::RR.load('_domainkey IN TXT "t=y; o=~;"')
+    assert_instance_of DNS::Zone::RR::TXT, rr, 'should be instance of TXT RR'
+    assert_equal '_domainkey', rr.label
+    assert_equal 'TXT', rr.type
+    assert_equal 't=y; o=~;', rr.text
+  end
 
   def test_load_a_rr_with_options_hash
     rr = DNS::Zone::RR.load(' IN A 10.2.3.1', { last_label: 'www' })


### PR DESCRIPTION
E.g. the following TXT records did not work prior to this change:

_domainkey IN TXT "t=y; o=~;"
selector._domainkey 3600 IN TXT "v=DKIM1; k=rsa; p=YOUR_KEY"
