### PR TITLE
Update domainname regex to work with relative names

### DIFF
--- a/lib/dns/zone/rr.rb
+++ b/lib/dns/zone/rr.rb
@@ -9,7 +9,7 @@ module DNS
       REGEX_KLASS = /(?<klass>IN)?/i
       REGEX_TYPE = /(?<type>A|AAAA|CNAME|HINFO|MX|NS|SOA|SPF|SRV|TXT|PTR)\s{1}/i
       REGEX_RR = /^(?<label>\S+|\s{1})\s*(?<ttl>#{REGEX_TTL})?\s*#{REGEX_KLASS}\s*#{REGEX_TYPE}\s*(?<rdata>[\s\S]*)$/i
-      REGEX_DOMAINNAME = /\S+\./i
+      REGEX_DOMAINNAME = /\S+/i
       REGEX_STRING = /((?:[^"\\]+|\\.)*)/
 
       # Load RR string data and return an instance representing the RR.


### PR DESCRIPTION
This example zone file:

$ORIGIN .
mattrideout.com MX 10 mail.mattrideout.com

Was previously being incorrectly parsed as:

mattrideout.com. MX 10 mail.mattrideout.

This update prevents "com" in the exchange from being stripped off.