### PR TITLE
add ability to parse zone file with multiple ORIGIN directives

### DIFF
--- a/lib/dns/zone.rb
+++ b/lib/dns/zone.rb
@@ -92,7 +92,11 @@ module DNS
         # read in special statments like $TTL and $ORIGIN
         if entry =~ /\$(ORIGIN|TTL)\s+(.+)/
           instance.ttl    = $2 if $1 == 'TTL'
-          instance.origin = $2 if $1 == 'ORIGIN'
+          if $1 == 'ORIGIN'
+            instance.origin ||= $2
+            options[:origin] ||= $2
+            options[:last_origin] = $2
+          end
           next
         end
 

--- a/lib/dns/zone/rr/record.rb
+++ b/lib/dns/zone/rr/record.rb
@@ -75,6 +75,10 @@ class DNS::Zone::RR::Record
       @label = captures[:label]
     end
 
+    # unroll records nested under other origins
+    unrolled_origin = options[:last_origin].sub(options[:origin], '').chomp('.') if options[:last_origin]
+    @label = "#{@label}.#{unrolled_origin}" if unrolled_origin && !unrolled_origin.empty?
+
     @ttl = captures[:ttl]
     captures[:rdata]
   end


### PR DESCRIPTION
I need to be able to parse a zone file with multiple ORIGIN directives. I can try to add this, but I'd like to see what the best API change would be. I've created a failing test to look at one option.

One option would be to return an array of zones when the zone file has multiple origins. This is slightly unexpected behavior, so another option would be to move it to another method, like `DNS::Zone.load_multiple` or something.

@lantins Any thoughts before I start my implementation?