### PR TITLE
add ruby 2.2.4 to the build matrix and bump 2.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@
 
 language: ruby
 rvm:
-  - 2.1.0
+  - 2.2.4
+  - 2.1.8
   - 2.0.0
   - 1.9.3
   - jruby-19mode


### PR DESCRIPTION
Start testing ruby 2.2.4 and bump ruby 2.1.0 to 2.1.8.