### PR TITLE
fix an edge case with multiple origins

### DIFF
--- a/lib/dns/zone/rr/record.rb
+++ b/lib/dns/zone/rr/record.rb
@@ -77,7 +77,9 @@ class DNS::Zone::RR::Record
 
     # unroll records nested under other origins
     unrolled_origin = options[:last_origin].sub(options[:origin], '').chomp('.') if options[:last_origin]
-    @label = "#{@label}.#{unrolled_origin}" if unrolled_origin && !unrolled_origin.empty?
+    if unrolled_origin && !unrolled_origin.empty?
+      @label = @label == '@' ? unrolled_origin : "#{@label}.#{unrolled_origin}"
+    end
 
     @ttl = captures[:ttl]
     captures[:rdata]

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -85,6 +85,7 @@ app1                    60 A     1.2.3.4
 app2                    60 A     1.2.3.5
 app3                    60 A     1.2.3.6
 $ORIGIN another.lividpenguin.com.
+@                     3600 A     1.1.1.1
 app1                    60 A     4.3.2.1
 
 EOL
@@ -190,11 +191,13 @@ EOL
   def test_load_multiple_origins
     zone = DNS::Zone.load(ZONE_FILE_MULTIPLE_ORIGINS_EXAMPLE)
     assert_equal 'lividpenguin.com.', zone.origin
-    assert_equal 11, zone.records.length, 'we should have multiple records (including SOA)'
+    assert_equal 12, zone.records.length, 'we should have multiple records (including SOA)'
     assert_equal 'app1.sub', zone.records[7].label
     assert_equal '1.2.3.4', zone.records[7].address
-    assert_equal 'app1.another', zone.records[10].label
-    assert_equal '4.3.2.1', zone.records[10].address
+    assert_equal 'another', zone.records[10].label
+    assert_equal '1.1.1.1', zone.records[10].address
+    assert_equal 'app1.another', zone.records[11].label
+    assert_equal '4.3.2.1', zone.records[11].address
   end
 
   def test_extract_entry_from_one_line


### PR DESCRIPTION
Found an edge case that wasn't handled properly. A record with the label of `@` under a sub-origin was not unrolled properly.