### PR TITLE
Fix warnings

### DIFF
--- a/lib/dns/zone.rb
+++ b/lib/dns/zone.rb
@@ -35,7 +35,7 @@ module DNS
     # @api public
     def soa
       # return the first SOA we find in the records array.
-      rr = @records.find { |rr| rr.type == "SOA" }
+      rr = @records.find { |record| record.type == "SOA" }
       return rr if rr
       # otherwise create a new SOA
       rr = DNS::Zone::RR::SOA.new
@@ -131,7 +131,6 @@ module DNS
       #     with a ";" (semicolon). 
 
       entries = []
-      mode = :line
       entry = ''
 
       parentheses_ref_count = 0
@@ -149,9 +148,6 @@ module DNS
 
         quotes = entry.count('"')
         has_quotes = quotes > 0
-
-        parentheses = entry.count('()')
-        has_parentheses = parentheses > 0
 
         if has_quotes
           character_strings = entry.scan(/("(?:[^"\\]+|\\.)*")/).join(' ')

--- a/test/rr/record_test.rb
+++ b/test/rr/record_test.rb
@@ -5,7 +5,7 @@ class RR_Record_Test < DNS::Zone::TestCase
   def test_rr_record_defaults
     rr = DNS::Zone::RR::Record.new
     assert_equal '@', rr.label, 'label is @, by default'
-    assert_equal nil, rr.ttl, 'ttl is nil, by default'
+    assert_nil rr.ttl, 'ttl is nil, by default'
   end
 
   def test_rr_record_with_label


### PR DESCRIPTION
This PR just fixes some small issues:
* warnings shown by Ruby (unused and shadowed variables)
* deprecation warning by minitest (`assert_equal nil, ...`)

These are shown when running `rake test` with Ruby 2.3.