### PR TITLE
Dump zone $ORIGIN/$TTL if present

### DIFF
--- a/lib/dns/zone.rb
+++ b/lib/dns/zone.rb
@@ -59,7 +59,7 @@ module DNS
         content << rr.dump
       end
 
-      content.join("\n") << "\n"
+      dump_directives << content.join("\n") << "\n"
     end
 
     # Generates pretty output of the zone and its records.
@@ -75,7 +75,7 @@ module DNS
         last_type = rr.type
       end
 
-      content.join("\n") << "\n"
+      dump_directives << content.join("\n") << "\n"
     end
 
     # Load the provided zone file data into a new DNS::Zone object.
@@ -184,6 +184,16 @@ module DNS
     end
 
     private
+
+    # Dumps the $ORIGIN and $TTL directives of this zone (for use by #dump and #dump_pretty).
+    #
+    # @api private
+    def dump_directives
+      content = ""
+      content << "$ORIGIN #{origin}\n" unless origin.to_s.empty?
+      content << "$TTL #{ttl}\n" unless ttl.to_s.empty?
+      content
+    end
 
     # Records sorted with more important types being at the top.
     #

--- a/test/zone_test.rb
+++ b/test/zone_test.rb
@@ -51,6 +51,7 @@ EOL
 
   # basic zone file example
   ZONE_FILE_BASIC_EXAMPLE =<<-EOL
+$ORIGIN lividpenguin.com.
 @ IN SOA ns0.lividpenguin.com. luke.lividpenguin.com. ( 2013101406 12h 15m 3w 3h )
 @ IN NS ns0.lividpenguin.com.
 @ IN MX 10 mail


### PR DESCRIPTION
`$ORIGIN` and `$TTL` directives are parsed when a zone file is loaded. However, the current implementation does not include this information in the dump methods. This PR extends `#dump` and `#dump_pretty` so that these directives are included (if specified).