### PR TITLE
Add Ruby 3.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
-# configuration settings for http://travis-ci.org
-sudo: false
-
 language: ruby
 rvm:
-  - 2.2.4
-  - 2.1.8
-  - 2.0.0
-  - rbx
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
+  - 3.1
+  - 3.2
+  - 3.3
+  - 3.4

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 ## HEAD
 
+* Add Ruby 3.4 compatibility
+* Fix frozen string literal warnings by avoiding in-place string mutations
+* Update minimum Ruby version to 2.4 (from 2.0)
+* Update SimpleCov dependency to >= 0.17 (from ~> 0.7.1)
+* Update Bundler dependency to >= 1.0 (from ~> 1.0) to allow modern versions
+* Update Travis CI config to test Ruby 2.4-3.4
+* Fix deprecated Minitest assertion (use assert_nil instead of assert_equal nil)
+
 ## 0.3.1 (2015-12-23)
 
 * Fix edge case when zone file has multiple `ORIGIN` directives.

--- a/dns-zone.gemspec
+++ b/dns-zone.gemspec
@@ -24,7 +24,7 @@ spec = Gem::Specification.new do |s|
   # cross platform gem dependencies
   #s.add_dependency('gli')
   #s.add_dependency('paint')
-  s.add_development_dependency('bundler',        '~> 1.0')
+  s.add_development_dependency('bundler',        '>= 1.0')
   s.add_development_dependency('rake',           '>= 9.0')
   s.add_development_dependency('minitest',       '~> 5.0')
   s.add_development_dependency('simplecov',      '~> 0.7.1')

--- a/dns-zone.gemspec
+++ b/dns-zone.gemspec
@@ -19,7 +19,7 @@ spec = Gem::Specification.new do |s|
   #s.default_executable  = 'dns-zone'
 
   # min ruby version
-  s.required_ruby_version = ::Gem::Requirement.new(">= 2.0")
+  s.required_ruby_version = ::Gem::Requirement.new(">= 2.4")
 
   # cross platform gem dependencies
   #s.add_dependency('gli')
@@ -27,7 +27,7 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency('bundler',        '>= 1.0')
   s.add_development_dependency('rake',           '>= 9.0')
   s.add_development_dependency('minitest',       '~> 5.0')
-  s.add_development_dependency('simplecov',      '~> 0.7.1')
+  s.add_development_dependency('simplecov',      '>= 0.17')
   s.add_development_dependency('yard',           '~> 0.8')
   s.add_development_dependency('inch',           '~> 0.6')
   s.add_development_dependency('guard-minitest', '~> 2.0')

--- a/lib/dns/zone.rb
+++ b/lib/dns/zone.rb
@@ -59,7 +59,7 @@ module DNS
         content << rr.dump
       end
 
-      content.join("\n") << "\n"
+      content.join("\n") + "\n"
     end
 
     # Generates pretty output of the zone and its records.
@@ -75,7 +75,7 @@ module DNS
         last_type = rr.type
       end
 
-      content.join("\n") << "\n"
+      content.join("\n") + "\n"
     end
 
     # Load the provided zone file data into a new DNS::Zone object.
@@ -132,7 +132,7 @@ module DNS
 
       entries = []
       mode = :line
-      entry = ''
+      entry = String.new
 
       parentheses_ref_count = 0
 
@@ -140,7 +140,7 @@ module DNS
         # strip comments unless escaped
         # strip comments, unless its escaped.
         # skip semicolons within "quote segments" (TXT records)
-        line = line.gsub(/((?<!\\);)(?=(?:[^"]|"[^"]*")*$).*/o, "").chomp
+        line = line.dup.gsub(/((?<!\\);)(?=(?:[^"]|"[^"]*")*$).*/o, "").chomp
 
         next if line.gsub(/\s+/, '').empty?
 
@@ -175,7 +175,7 @@ module DNS
             #entries << entry
           end
           entries << entry
-          entry = ''
+          entry = String.new
         end
 
       end

--- a/lib/dns/zone/rr.rb
+++ b/lib/dns/zone/rr.rb
@@ -24,7 +24,7 @@ module DNS
       def self.load(string, options = {})
         # strip comments, unless its escaped.
         # skip semicolons within "quote segments" (TXT records)
-        string.gsub!(/((?<!\\);)(?=(?:[^"]|"[^"]*")*$).*/o, "")
+        string = string.gsub(/((?<!\\);)(?=(?:[^"]|"[^"]*")*$).*/o, "")
 
         captures = string.match(REGEX_RR)
         return nil unless captures

--- a/lib/dns/zone/rr/record.rb
+++ b/lib/dns/zone/rr/record.rb
@@ -64,7 +64,7 @@ class DNS::Zone::RR::Record
   def load_general_and_get_rdata(string, options = {})
     # strip comments, unless its escaped.
     # skip semicolons within "quote segments" (TXT records)
-    string.gsub!(/((?<!\\);)(?=(?:[^"]|"[^"]*")*$).*/o, "")
+    string = string.gsub(/((?<!\\);)(?=(?:[^"]|"[^"]*")*$).*/o, "")
 
     captures = string.match(DNS::Zone::RR::REGEX_RR)
     return nil unless captures

--- a/test/rr/record_test.rb
+++ b/test/rr/record_test.rb
@@ -5,7 +5,7 @@ class RR_Record_Test < DNS::Zone::TestCase
   def test_rr_record_defaults
     rr = DNS::Zone::RR::Record.new
     assert_equal '@', rr.label, 'label is @, by default'
-    assert_equal nil, rr.ttl, 'ttl is nil, by default'
+    assert_nil rr.ttl, 'ttl is nil, by default'
   end
 
   def test_rr_record_with_label


### PR DESCRIPTION
* Add Ruby 3.4 compatibility (all tests pass)
* Fix frozen string literal warnings by avoiding in-place string mutations
* Update minimum Ruby version to 2.4 (from 2.0)
* Update SimpleCov dependency to >= 0.17 (from ~> 0.7.1)
* Update Bundler dependency from ~> 1.0 to >= 1.0 to allow modern versions
* Update Travis CI config to test Ruby 2.4-3.4
* Fix deprecated Minitest assertion (use assert_nil instead of assert_equal nil)